### PR TITLE
fix: implement CONFIG_SCHEMA as requiered when using async_setup

### DIFF
--- a/custom_components/enphase_envoy_raw_data/__init__.py
+++ b/custom_components/enphase_envoy_raw_data/__init__.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import CONF_HOST
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from pyenphase import Envoy
 
@@ -32,6 +33,8 @@ if TYPE_CHECKING:
     from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:


### PR DESCRIPTION
Fix warning reported by Hassfest validation:

[CONFIG_SCHEMA] Integrations which implement 'async_setup' or 'setup' must define either 'CONFIG_SCHEMA', 'PLATFORM_SCHEMA' or 'PLATFORM_SCHEMA_BASE'. If the integration has no configuration parameters, can only be set up from platforms or can only be set up from config entries, one of the helpers cv.empty_config_schema, cv.platform_only_config_schema or cv.config_entry_only_config_schema can be used.